### PR TITLE
add dependencies to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,15 @@ classifiers =
 packages = nfinder
 python_requires = >=3.7
 include_package_data = True
+install_requires =
+    numpy
+    matplotlib
+    napari
+    scipy
+    scikit-image
+    pandas
+    magicgui
+    napari_plugin_engine
 
 [options.entry_points]
 napari.plugin =


### PR DESCRIPTION
Hi there,  not sure if this is something you're still developing, but while checking how many napari plugins were actually "installable", I found that you have a number of missing dependencies in your plugin (such that `pip install` of your plugin will likely fail most of the time) 

This PR fixes that, (and will require a new release on pypi once merged)

cheers